### PR TITLE
Fix election / block times mixup

### DIFF
--- a/src/jobs/generate_block_stats.js
+++ b/src/jobs/generate_block_stats.js
@@ -18,11 +18,11 @@ const generateBlockStats = async () => {
   const blockTimeDay = stats.blockTimes.lastDay.avg
   const blockTimeDayStdDev = stats.blockTimes.lastDay.stddev
 
-  const blockTimeWeek = stats.electionTimes.lastWeek.avg
-  const blockTimeWeekStdDev = stats.electionTimes.lastWeek.stddev
+  const blockTimeWeek = stats.blockTimes.lastWeek.avg
+  const blockTimeWeekStdDev = stats.blockTimes.lastWeek.stddev
 
-  const blockTimeMonth = stats.electionTimes.lastMonth.avg
-  const blockTimeMonthStdDev = stats.electionTimes.lastMonth.stddev
+  const blockTimeMonth = stats.blockTimes.lastMonth.avg
+  const blockTimeMonthStdDev = stats.blockTimes.lastMonth.stddev
 
   const electionTimeDay = stats.electionTimes.lastDay.avg
 


### PR DESCRIPTION
I realized the wrong fields were being used to populate block times week and block times month data (I used election times instead)

I'm not sure how this will change the redis timeseries stuff, or how we "clear" the existing wrong fields from that. But just wanted to save this in PR format to revisit. Just going to not display these stats for now on explorer-beta.