### PR TITLE
Fix hotspot stats job failing.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@babel/preset-env": "^7.12.11",
     "@fnando/keyring": "^0.4.0",
     "@helium/crypto": "^3.7.0",
-    "@helium/http": "^3.49.0",
+    "@helium/http": "^3.53.0",
     "@helium/transactions": "^3.30.0",
     "bcryptjs": "^2.4.3",
     "camelcase-keys": "^6.2.2",

--- a/src/jobs/generate_hotspot_stats.js
+++ b/src/jobs/generate_hotspot_stats.js
@@ -1,69 +1,42 @@
-const { countBy, round, uniqBy } = require('lodash')
-const { sub, compareAsc, getUnixTime } = require('date-fns')
+const { round } = require('lodash')
 const { Sample } = require('redis-time-series-ts')
 const { redisClient } = require('../helpers/redis')
-const { client, TAKE_MAX } = require('../helpers/client')
+const { client } = require('../helpers/client')
 
-const backfillHotspotsCount = async () => {
-  const hotspots = await (await client.hotspots.list()).take(500000)
+const generateStats = async () => {
+  const {
+    hotspots,
+    hotspotsOnline,
+    cities,
+    countries,
+    hotspotsDataonly,
+  } = await client.stats.counts()
+
+  const onlinePct = round(hotspotsOnline / hotspots, 4)
 
   const now = new Date()
 
-  console.log(getUnixTime(now), hotspots.length)
-
+  await redisClient.add(new Sample('hotspots_count', hotspots, now), [], 0)
   await redisClient.add(
-    new Sample('hotspots_count', hotspots.length, now),
+    new Sample('hotspots_online_count', hotspotsOnline, now),
     [],
     0,
   )
-
-  await Promise.all(
-    Array.from({ length: 364 }, async (x, i) => {
-      const date = sub(now, { days: i + 1 })
-      // count hotspots where the time added is earlier than the given date
-      const count = countBy(
-        hotspots,
-        (h) => compareAsc(new Date(h.timestampAdded), date) === -1,
-      ).true
-
-      return redisClient.add(
-        new Sample('hotspots_count', count, date),
-        [],
-        3600,
-      )
-    }),
+  await redisClient.add(
+    new Sample('hotspots_data_only_count', hotspotsDataonly, now),
+    [],
+    0,
   )
-}
+  await redisClient.add(new Sample('hotspots_count', hotspots, now), [], 0)
 
-const generateStats = async () => {
-  const hotspots = await (await client.hotspots.list()).take(TAKE_MAX)
-  const hotspotsCount = hotspots.length
-  const onlineHotspotsCount = countBy(hotspots, 'status.online')?.online
-  const onlinePct = round(onlineHotspotsCount / hotspotsCount, 4)
-  const ownersCount = uniqBy(hotspots, 'owner').length
-  const citiesCount = uniqBy(hotspots, 'geocode.cityId').length
-  const countriesCount = uniqBy(hotspots, 'geocode.shortCountry').length
-
-  const now = new Date()
-
-  await redisClient.add(new Sample('hotspots_count', hotspotsCount, now), [], 0)
   await redisClient.add(
     new Sample('hotspots_online_pct', onlinePct, now),
     [],
     0,
   )
+  await redisClient.add(new Sample('hotspots_cities_count', cities, now), [], 0)
   await redisClient.add(
-    new Sample('hotspots_owners_count', ownersCount, now),
-    [],
-    0,
-  )
-  await redisClient.add(
-    new Sample('hotspots_cities_count', citiesCount, now),
-    [],
-    0,
-  )
-  await redisClient.add(
-    new Sample('hotspots_countries_count', countriesCount, now),
+    new Sample('hotspots_countries_count', countries, now),
     [],
     0,
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -878,6 +878,15 @@
     create-hash "^1.2.0"
     libsodium-wrappers "^0.7.6"
 
+"@helium/crypto@^3.45.0":
+  version "3.45.0"
+  resolved "https://registry.yarnpkg.com/@helium/crypto/-/crypto-3.45.0.tgz#2892aaac8f35865cd32a91222fd5ffbe9f973e08"
+  integrity sha512-J89U4GsLLjODPEPTD5m6q6w6zjbtJjYTxrXAF+Sp+Aqq9nPSOTvQ4gx12dfKXfPT/Rq1vrZ5/CIVXYPhQ7PTJQ==
+  dependencies:
+    bs58 "^4.0.1"
+    create-hash "^1.2.0"
+    libsodium-wrappers "^0.7.6"
+
 "@helium/crypto@^3.7.0":
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/@helium/crypto/-/crypto-3.7.0.tgz#9645cad30443582a3cf646457419d8480add785a"
@@ -887,19 +896,20 @@
     create-hash "^1.2.0"
     libsodium-wrappers "^0.7.6"
 
-"@helium/currency@^3.45.0":
-  version "3.45.0"
-  resolved "https://registry.yarnpkg.com/@helium/currency/-/currency-3.45.0.tgz#326933225047601f447209fb9c77c6d4b114c381"
-  integrity sha512-6hajnB+L5OQgbQJyGzzYrHlcpRnt1j9thjt+zKhLP672VgfqJWaBs5unI+yhqHvF3JPB2/DsLj3/oT4hL0z84A==
+"@helium/currency@^3.52.0":
+  version "3.52.0"
+  resolved "https://registry.yarnpkg.com/@helium/currency/-/currency-3.52.0.tgz#68b8ec1c2db73b7c88f54c1b59686a5ade148986"
+  integrity sha512-L91EKuzO+X4v45df8fgr9ihR1WTzThTQIx3Uh2bQwpwkDjxvxdI6xq43VEhz0+y7JN2XGRl3tX4ljQST+Azw4Q==
   dependencies:
     bignumber.js "^9.0.0"
 
-"@helium/http@^3.49.0":
-  version "3.49.0"
-  resolved "https://registry.yarnpkg.com/@helium/http/-/http-3.49.0.tgz#052fc444b1f91006e959265167273516bfcd9918"
-  integrity sha512-CNGWZfSqwGLWkB9uoDO5N7fqFHPDCRARlx6TmCsG89XbcQjAzePLIF1vys9qKdxuVy3TyscAbGe2bQ33DcLlPQ==
+"@helium/http@^3.53.0":
+  version "3.53.0"
+  resolved "https://registry.yarnpkg.com/@helium/http/-/http-3.53.0.tgz#b9fd84427a2a8fbcb1187f6e8738403cea2f5922"
+  integrity sha512-8ibrAKaY8YgJYvFWVm9S0WcfB60rvkmhX5wpRGqXM8lWZ+IMY2chWGEhV7U4OxVBVEMhmiyVLH0OtwVojXrs6w==
   dependencies:
-    "@helium/currency" "^3.45.0"
+    "@helium/crypto" "^3.45.0"
+    "@helium/currency" "^3.52.0"
     axios "^0.21.1"
     camelcase-keys "^6.2.2"
     qs "^6.9.3"


### PR DESCRIPTION
We're going to use the stats/count route instead of iterating through all of the hotspots to generate these stats. In place of `hotspots_owners_count` we will use `hotspots_data_only_count`.